### PR TITLE
Refactor/is reconed

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,9 +51,8 @@ def main(args):
     im_path1 = os.path.join(args.input_dir, args.im_path1)
     im_path2 = os.path.join(args.input_dir, args.im_path2)
 
-    is_flip = False
     if args.flip_check:
-        im_path2, is_flip = flip_check(im_path1, im_path2, args.device)
+        im_path2 = flip_check(im_path1, im_path2, args.device)
 
     im_name_1 = os.path.splitext(os.path.basename(im_path1))[0]
     im_name_2 = os.path.splitext(os.path.basename(im_path2))[0]
@@ -63,10 +62,6 @@ def main(args):
     if args.is_reconed == False:
         ii2s.invert_images_in_W([*im_set])
         ii2s.invert_images_in_FS([*im_set])
-    elif is_flip:
-        # flip image embedding
-        ii2s.invert_images_in_W([im_path2])
-        ii2s.invert_images_in_FS([im_path2])
 
     if args.save_all:
         args.save_dir = os.path.join(args.output_dir, f'{im_name_1}_{im_name_2}_{args.version}')

--- a/main.py
+++ b/main.py
@@ -113,7 +113,6 @@ if __name__ == "__main__":
     # utils
     parser.add_argument('--version', type=str, default='v1', help='version name')
     parser.add_argument('--save_all', action='store_true',help='save all output from whole process')
-    parser.add_argument('--is_reconed', action='store_true', help='if true, skip the embedding steps')
     parser.add_argument('--embedding_dir', type=str, default='./output/', help='embedding vector directory')
 
     # I/O arguments

--- a/main.py
+++ b/main.py
@@ -1,17 +1,16 @@
 from typing import Set, List
 
+import os
+import random
+import shutil
 import argparse
 
 import torch
-import random
 import numpy as np
-import os
-from models.Embedding import Embedding
-from models.Alignment import Alignment
 
 from utils.kp_diff import flip_check
-
-import shutil
+from models.Alignment import Alignment
+from models.Embedding import Embedding
 
 
 def set_seed(seed: int) -> None:

--- a/utils/kp_diff.py
+++ b/utils/kp_diff.py
@@ -29,9 +29,9 @@ def flip_check(im_path1, im_path2, device):
         im2_flip = Image.fromarray(im2_flip)
         save_im_path2 = im_path2.replace(im_name_2, im_name_2 + '_flip')
         im2_flip.save(save_im_path2)
-        return save_im_path2, True
+        return save_im_path2
     print(f'cal. kp. diff. time : {time.time() - start_time}')
-    return im_path2, False
+    return im_path2
 
 if __name__ == '__main__':
     input_dir =''


### PR DESCRIPTION
- Remove the `is_recond` argument since we can check images that needed to be embedded.
- Previously, im2_flipped was always embedded no matter it is embedded before or not. This PR dynamically finds images that need to be embedded.