### PR TITLE
refactor: _2D, _3D -> TWO_D, THREE_D 변경

### DIFF
--- a/models/Alignment.py
+++ b/models/Alignment.py
@@ -65,9 +65,9 @@ class Alignment(nn.Module):
         if self.opts.kp_loss:
             # self.setup_align_loss_builder(no_face=False)
             if self.opts.kp_type =='2D':
-                self.kp_extractor = face_alignment.FaceAlignment(face_alignment.LandmarksType._2D, flip_input=False, device=opts.device)
+                self.kp_extractor = face_alignment.FaceAlignment(face_alignment.LandmarksType.TWO_D, flip_input=False, device=opts.device)
             else:
-                self.kp_extractor = face_alignment.FaceAlignment(face_alignment.LandmarksType._3D, flip_input=False, device=opts.device)
+                self.kp_extractor = face_alignment.FaceAlignment(face_alignment.LandmarksType.THREE_D, flip_input=False, device=opts.device)
             for param in self.kp_extractor.face_alignment_net.parameters():
                 param.requires_grad = False
             self.l2 = torch.nn.MSELoss()

--- a/utils/kp_diff.py
+++ b/utils/kp_diff.py
@@ -11,7 +11,7 @@ def flip_check(im_path1, im_path2, device):
 
     im_name_2 = os.path.splitext(os.path.basename(im_path2))[0]
 
-    kp_extractor = face_alignment.FaceAlignment(face_alignment.LandmarksType._3D, flip_input=False, device=device)
+    kp_extractor = face_alignment.FaceAlignment(face_alignment.LandmarksType.THREE_D, flip_input=False, device=device)
 
     im1 = io.imread(im_path1)
     im2 = io.imread(im_path2)


### PR DESCRIPTION
해당 모델을 실행하는 도중에 _3D 속성을 찾을 수 없다는 에러를 마주함.
face_alignment 라이브러리를 찾아 가보니 해당 필드명이 바뀌어 있어 수정하였습니다. 